### PR TITLE
Refactor back to separate methods

### DIFF
--- a/SwiftyJSONModel/JSONExtension.swift
+++ b/SwiftyJSONModel/JSONExtension.swift
@@ -10,9 +10,24 @@ import Foundation
 import SwiftyJSON
 
 public extension JSON {
-    public func value<T: Any>() throws -> T {
-        guard let value = object as? T else { throw JSONModelError.invalidElement }
-        return value
+    public func value() throws -> Bool {
+        guard let boolValue = bool else { throw JSONModelError.invalidElement }
+        return boolValue
+    }
+    
+    public func value() throws -> Int {
+        guard let intValue = int else { throw JSONModelError.invalidElement }
+        return intValue
+    }
+    
+    public func value() throws -> Double {
+        guard let doubleValue = double else { throw JSONModelError.invalidElement }
+        return doubleValue
+    }
+    
+    public func value() throws -> String {
+        guard let stringValue = string else { throw JSONModelError.invalidElement }
+        return stringValue
     }
     
     public func arrayValue() throws -> [JSON] {

--- a/SwiftyJSONModel/JSONTypes.swift
+++ b/SwiftyJSONModel/JSONTypes.swift
@@ -17,19 +17,26 @@ public protocol JSONRepresentable {
     var jsonValue: JSON { get }
 }
 
-public extension JSONInitializable {
-    public init(json: JSON) throws {
-        self = try json.value()
-    }
-}
-
 public extension JSONRepresentable {
-    public var jsonValue: JSON {
-        return JSON(self)
-    }
+    public var jsonValue: JSON { return JSON(self) }
 }
 
-extension String: JSONInitializable, JSONRepresentable {}
-extension Bool: JSONInitializable, JSONRepresentable {}
-extension Int: JSONInitializable, JSONRepresentable {}
-extension Double: JSONInitializable, JSONRepresentable {}
+extension String: JSONInitializable, JSONRepresentable {
+    public init(json: JSON) throws { self = try json.value() }
+    public var jsonValue: JSON { return JSON(self) }
+}
+
+extension Bool: JSONInitializable, JSONRepresentable {
+    public init(json: JSON) throws { self = try json.value() }
+    public var jsonValue: JSON { return JSON(self) }
+}
+
+extension Int: JSONInitializable, JSONRepresentable {
+    public init(json: JSON) throws { self = try json.value() }
+    public var jsonValue: JSON { return JSON(self) }
+}
+
+extension Double: JSONInitializable, JSONRepresentable {
+    public init(json: JSON) throws { self = try json.value() }
+    public var jsonValue: JSON { return JSON(self) }
+}

--- a/SwiftyJSONModelTests/JSONExtensionTests.swift
+++ b/SwiftyJSONModelTests/JSONExtensionTests.swift
@@ -21,7 +21,9 @@ class JSONExtensionTests: XCTestCase {
         }
         XCTAssertEqual(try? JSON(true).value() as Bool, true)
         XCTAssertEqual(try? JSON(3).value() as Int, 3)
+        XCTAssertEqual(try? JSON(0.0).value() as Int, 0)
         XCTAssertEqual(try? JSON(3.0).value() as Double, 3.0)
+        XCTAssertEqual(try? JSON(-5).value() as Double, -5)
         XCTAssertEqual(try? JSON("test").value() as String, "test")
     }
     


### PR DESCRIPTION
This Pull Request fixes [this bug](https://github.com/alickbass/SwiftyJSONModel/issues/12)

Now we implicitly specify that by default we support only `String`, `Bool`, `Double`, `Int` as primitives to work with JSON. We remove usage of method that returns `Any` as this method introduced the issue that caused invalid parsing of numbers in the `JSON`